### PR TITLE
Fix Hollow moves (remove Ghoul move)

### DIFF
--- a/monsterhearts/hollow/index.html
+++ b/monsterhearts/hollow/index.html
@@ -147,10 +147,6 @@
 				When you <i>Gaze Into the Abyss</i>, on a 7 or higher the abyss will also show you what you must become, and you can permanently swap two of your stats.
 			</div>
 			<div class="charMove">
-				<input type="checkbox" name="moveSix" id="moveSix" value="Ending"><label for="moveSix"> Ending:</label> 
-				You remember every detail of your death. When you tell someone about it, give them the Condition <b>morbid</b> and roll to <i>Turn Them On</i> with Cold.
-			</div>
-			<div class="charMove">
 				<input type="checkbox" name="moveSix" id="moveSix" value="Strange Impressions"><label for="moveSix"> Strange Impressions:</label> 
 				When a main character either harms you or helps you heal, you can respond by studying them with wide eyes. If you do, temporarily gain one of their Skin Moves and add it to your character sheet. It disappears once you use it.
 			</div>


### PR DESCRIPTION
"Ending" is a Ghoul move, but was accidentally included in the Hollow sheet.